### PR TITLE
Fix gateway IP determination

### DIFF
--- a/reconnect-vpn.sh
+++ b/reconnect-vpn.sh
@@ -73,7 +73,7 @@ function check_dsm_status() {
 function check_gateway_ping() {
 	local CLIENT_IP=$(/usr/syno/bin/synovpnc get_conn | grep "Client IP" | awk '{ print $4 }')
 	local TUNNEL_INTERFACE=$(ip addr | grep $CLIENT_IP | awk '{ print $7 }')
-	local GATEWAY_IP=$(ip route | grep -v "src $CLIENT_IP" | grep $TUNNEL_INTERFACE | awk '{ print $3 }' | head -n 1)
+	local GATEWAY_IP=$(ip route | grep "src $CLIENT_IP" | grep $TUNNEL_INTERFACE | awk '{ print $1 }' | head -n 1)
 	if ping -c 1 -i 1 -w 15 -I $TUNNEL_INTERFACE $GATEWAY_IP > /dev/null 2>&1; then
 		echo "[I] The gateway IP $GATEWAY_IP responded to ping."
 		return 0


### PR DESCRIPTION
On my Synology (DSM 6.2.3-25426 Update 3) the script did not produce the correct gateway address if setting the detection method to "check_gateway_ping". It produced only empty results, causing the ping to fail.

For me, excluding all results having the wanted client IP (using -v) doesn't make much sense anyway if we are looking for a route that the VPN client is accessing.

Removing that, I also found that the print command obviously referenced the 3rd column of the output (which for me is structured as follows: 
`<gateway> dev <interface> proto kernel scope link src <client ip>`

Thus i changed that to actually return the gateway's IP.