### PR TITLE
Fix TUNNEL_INTERFACE env when there are many interfaces with the same IP

### DIFF
--- a/reconnect-vpn.sh
+++ b/reconnect-vpn.sh
@@ -95,7 +95,7 @@ function check_dsm_status() {
 
 function check_ping() {
 	local CLIENT_IP=$(/usr/syno/bin/synovpnc get_conn | grep "Client IP" | awk '{ print $4 }')
-	local TUNNEL_INTERFACE=$(ip addr | grep $CLIENT_IP | awk '{ print $NF }')
+	local TUNNEL_INTERFACE=$(ip addr | grep $CLIENT_IP | awk 'END{ print $NF }')
 	if [[ $VPN_CHECK_METHOD = "gateway_ping" ]]; then
 		local PING_ADDRESS=$(ip route | grep $TUNNEL_INTERFACE | grep -oE '([0-9]+\.){3}[0-9]+ dev' | awk '{ print $1 }' | head -n 1)
 		echo "[I] Pinging VPN gateway address $PING_ADDRESS."


### PR DESCRIPTION
Hi,
my tunnel IP address is 10.1.0.2/24
the command:

ip addr | grep 10.1.0.2 | awk '{ print $NF }'

The output in my case would be:

    inet 10.1.0.2/24 scope global tun0
    inet 10.1.0.2/24 scope global tun1

This will result two values for the TUNNEL_INTERFACE

TUNNEL_INTERFACE=$(ip addr | grep 10.1.0.2 | awk '{ print $NF }')
echo $TUNNEL_INTERFACE
tun0 tun1

This will result the ping test to go through tun0 not through tun1 and the ping will fail.
![image](https://github.com/user-attachments/assets/e92589d1-8abc-424f-9eea-67b773d1423c)

FIX:
TUNNEL_INTERFACE=$(ip addr | grep 10.1.0.2 | awk 'END{ print $NF }')
after the change:
![image](https://github.com/user-attachments/assets/fad54acb-021f-4598-91cb-651ddf0255c2)
